### PR TITLE
loader menu: Add new frame option with rounded corners

### DIFF
--- a/stand/forth/frames.4th
+++ b/stand/forth/frames.4th
@@ -53,6 +53,13 @@ variable fill
 0x2514 constant slb_el
 0x2510 constant srt_el
 0x2518 constant srb_el
+\ Rounded frames
+0x2500 constant rh_el
+0x2502 constant rv_el
+0x256d constant rlt_el
+0x2570 constant rlb_el
+0x256e constant rrt_el
+0x256f constant rrb_el
 \ Double frames
 0x2550 constant dh_el
 0x2551 constant dv_el
@@ -93,6 +100,16 @@ only forth definitions also frame-drawing
 	slb_el lb_el !
 	srt_el rt_el !
 	srb_el rb_el !
+;
+
+: f_rounded	( -- )	\ set frames to rounded
+	boot_serial? if f_ascii exit then
+	rh_el h_el !
+	rv_el v_el !
+	rlt_el lt_el !
+	rlb_el lb_el !
+	rrt_el rt_el !
+	rrb_el rb_el !
 ;
 
 : f_double	( -- )	\ set frames to double

--- a/stand/forth/menu.4th
+++ b/stand/forth/menu.4th
@@ -38,7 +38,8 @@ vocabulary menu-command-helpers
 only forth also menu-infrastructure definitions
 
 f_double        \ Set frames to double (see frames.4th). Replace with
-                \ f_single if you want single frames.
+                \ f_single if you want single frames or
+                \ f_rounded if you want single frames with rounded borders.
 46 constant dot \ ASCII definition of a period (in decimal)
 
  5 constant menu_default_x         \ default column position of timeout
@@ -1004,11 +1005,13 @@ only forth definitions also menu-infrastructure
 		drop \ no custom frame type
 	else ( 1 )  2dup s" single" compare-insensitive 0= if ( 2 )
 		f_single ( see frames.4th )
-	else ( 2 )  2dup s" double" compare-insensitive 0= if ( 3 )
+	else ( 2 )  2dup s" rounded" compare-insensitive 0= if ( 3 )
+		f_rounded ( see frames.4th )
+	else ( 3 )  2dup s" double" compare-insensitive 0= if ( 4 )
 		f_double ( see frames.4th )
-	else ( 3 ) s" none" compare-insensitive 0= if ( 4 )
+	else ( 4 ) s" none" compare-insensitive 0= if ( 5 )
 		drop FALSE \ don't draw a box
-	( 4 ) then ( 3 ) then ( 2 )  then ( 1 ) then
+	( 5 ) then ( 4 ) then ( 3 ) then ( 2 )  then ( 1 ) then
 	if
 		42 13 menuX @ 3 - menuY @ 1- box \ Draw frame (w,h,x,y)
 	then

--- a/stand/forth/menu.4th.8
+++ b/stand/forth/menu.4th.8
@@ -24,7 +24,7 @@
 .\"
 .\" $FreeBSD$
 .\"
-.Dd August 6, 2013
+.Dd March 20, 2022
 .Dt MENU.4TH 8
 .Os
 .Sh NAME
@@ -126,11 +126,13 @@ The default is
 .It Va loader_menu_frame
 Sets the desired box style to draw around the boot menu.
 Possible values are:
-.Dq Li single
-.Pq the default ,
+.Dq Li single ,
+.Dq Li rounded ,
 .Dq Li double ,
 and
 .Dq Li none .
+The default is
+.Dq Li double .
 .It Va loader_menu_timeout_x
 Sets the desired column position of the timeout countdown text.
 Default is 4.

--- a/stand/lua/drawer.lua
+++ b/stand/lua/drawer.lua
@@ -503,6 +503,14 @@ drawer.frame_styles = {
 		top_right	= "\xE2\x94\x90",
 		bottom_right	= "\xE2\x94\x98",
 	},
+	["rounded"] = {
+		horizontal	= "\xE2\x94\x80",
+		vertical	= "\xE2\x94\x82",
+		top_left	= "\xE2\x95\xAD",
+		bottom_left	= "\xE2\x95\xB0",
+		top_right	= "\xE2\x95\xAE",
+		bottom_right	= "\xE2\x95\xAF",
+	},
 	["double"] = {
 		horizontal	= "\xE2\x95\x90",
 		vertical	= "\xE2\x95\x91",


### PR DESCRIPTION
Suitable for serial consoles: more closely resembles the framebuffered version.

To use it, add to /boot/loader.conf:

    loader_menu_frame="rounded"

    ╭────────── Welcome to FreeBSD ───────────╮
    │                                         │
    │  1. Boot Multi user [Enter]             │
    │  2. Boot Single user                    │
    │  3. Escape to loader prompt             │
    │  4. Reboot                              │
    │  5. Cons: Dual (Serial primary)         │
    │                                         │
    │  Options:                               │
    │  6. Kernel: default/kernel (1 of 1)     │
    │  7. Boot Options                        │
    │                                         │
    │                                         │
    ╰─────────────────────────────────────────╯