### PR TITLE
NanoBSD: Fix cust_comconsole pattern

### DIFF
--- a/tools/tools/nanobsd/defaults.sh
+++ b/tools/tools/nanobsd/defaults.sh
@@ -715,10 +715,10 @@ UsbDevice ( ) {
 
 cust_comconsole ( ) (
 	# Enable getty on console
-	sed -i "" -e /tty[du]0/s/off/on/ ${NANO_WORLDDIR}/etc/ttys
+	sed -i "" -e '/^tty[du]0/s/off/onifconsole/' ${NANO_WORLDDIR}/etc/ttys
 
-	# Disable getty on syscons devices
-	sed -i "" -e '/^ttyv[0-8]/s/	on/	off/' ${NANO_WORLDDIR}/etc/ttys
+	# Disable getty on syscons or vt devices
+	sed -i "" -E '/^ttyv[0-8]/s/\ton(ifexists)?/\toff/' ${NANO_WORLDDIR}/etc/ttys
 
 	# Tell loader to use serial console early.
 	echo "${NANO_BOOT2CFG}" > ${NANO_WORLDDIR}/boot.config


### PR DESCRIPTION
The current patterns are outdated, and may produce `offifexists`.

Per nanobsd(8), fix the outdated patterns to:

1. Disable getty(8) on the virtual syscons(4) or vt(4) terminals (`/dev/ttyv*`).

2. Enable the use of the first serial port as the system console.

Given that we now have a single ttys(5) for all architectures.

History: `ttyd0` was a special device file created by sio(4).
         `ttyu0` is special device file created by uart(4), currently
         set to `onifexists`.

Relevant commits:
- e310437971b858108259431d4a452deab9cdadaf
- f2d7865517e54203d6773ea7a407356fd8f06ef7
- f4d811f0b26466000e2001df13ab3bb3876a271b