### PR TITLE
Update legacy sysctls

### DIFF
--- a/tests/sys/cddl/zfs/tests/cli_root/zpool_destroy/zpool_destroy_004_pos.ksh
+++ b/tests/sys/cddl/zfs/tests/cli_root/zpool_destroy/zpool_destroy_004_pos.ksh
@@ -136,7 +136,7 @@ done
 # A longer test that simulates a more realistic send|receive that exceeds
 # the size of arc memory by 1/3 and gets interrupted a decent amount of
 # time after the start of the run.
-arcmem=$(sysctl -n vfs.zfs.arc_max)
+arcmem=$(sysctl -n vfs.zfs.arc.max)
 # ARC will use 2xdatasz memory since it caches both the src and dst copies
 datasz=$((arcmem / 1048576 * 2 / 3))
 log_note "Running longer test with ${datasz}MB of data"

--- a/tools/tools/nanobsd/rescue/Files/root/ZFS_Create.txt
+++ b/tools/tools/nanobsd/rescue/Files/root/ZFS_Create.txt
@@ -26,10 +26,10 @@ zfs_load="YES"
 vfs.root.mountfrom="zfs:boot/ROOT/root"
 #ZFS optional
 vm.kmem_size="8G"
-vfs.zfs.arc_min="1G"
-vfs.zfs.arc_max="2G"
-vfs.zfs.prefetch_disable="1"
-vfs.zfs.zil_disable=1
+vfs.zfs.arc.min="1G"
+vfs.zfs.arc.max="2G"
+vfs.zfs.prefetch.disable="1"
+vfs.zfs.zil.replay_disable=1
 vfs.zfs.zio.use_uma=0
 #Power savings
 hw.pci.do_power_nodriver=3

--- a/tools/tools/netrate/tcpp/README
+++ b/tools/tools/netrate/tcpp/README
@@ -84,7 +84,7 @@ In my testing, I use loader.conf entries of:
 
 kern.ipc.maxsockets=1000000
 net.inet.tcp.maxtcptw=3000000
-kern.ipc.somaxconn=49152
+kern.ipc.soacceptqueue=49152
 kern.ipc.nmbjumbo16=262144
 kern.ipc.nmbjumbo9=262144
 kern.ipc.nmbjumbop=262144

--- a/tools/tools/sysdoc/tunables.mdoc
+++ b/tools/tools/sysdoc/tunables.mdoc
@@ -807,7 +807,7 @@ kern.ipc.nsfbufs
 kern.ipc.numopensockets
 
 ---
-kern.ipc.somaxconn
+kern.ipc.soacceptqueue
 int
 
 The maximum pending socket connection queue size.

--- a/usr.sbin/bsdinstall/scripts/zfsboot
+++ b/usr.sbin/bsdinstall/scripts/zfsboot
@@ -70,7 +70,7 @@ f_include $BSDCFG_SHARE/variable.subr
 : ${ZFSBOOT_VDEV_TYPE:=stripe}
 
 #
-# Should we use sysctl(8) vfs.zfs.min_auto_ashift=12 to force 4K sectors?
+# Should we use sysctl(8) vfs.zfs.vdev.min_auto_ashift=12 to force 4K sectors?
 #
 : ${ZFSBOOT_FORCE_4K_SECTORS:=1}
 
@@ -223,7 +223,7 @@ PRINTF_CONF="printf '%s=\"%%s\"\\\n' %s >> \"%s\""
 PRINTF_FSTAB='printf "$FSTAB_FMT" "%s" "%s" "%s" "%s" "%s" "%s" >> "%s"'
 SHELL_TRUNCATE=':> "%s"'
 SWAP_GMIRROR_LABEL='gmirror label swap %s'
-SYSCTL_ZFS_MIN_ASHIFT_12='sysctl vfs.zfs.min_auto_ashift=12'
+SYSCTL_ZFS_MIN_ASHIFT_12='sysctl vfs.zfs.vdev.min_auto_ashift=12'
 UMOUNT='umount "%s"'
 ZFS_CREATE_WITH_OPTIONS='zfs create %s "%s"'
 ZFS_MOUNT='zfs mount "%s"'
@@ -257,7 +257,7 @@ msg_encrypt_disks="Encrypt Disks?"
 msg_encrypt_disks_help="Use geli(8) to encrypt all data partitions"
 msg_error="Error"
 msg_force_4k_sectors="Force 4K Sectors?"
-msg_force_4k_sectors_help="Align partitions to 4K sector boundries and set vfs.zfs.min_auto_ashift=12"
+msg_force_4k_sectors_help="Align partitions to 4K sector boundries and set vfs.zfs.vdev.min_auto_ashift=12"
 msg_freebsd_installer="$OSNAME Installer"
 msg_geli_password="Enter a strong passphrase, used to protect your encryption keys. You will be required to enter this passphrase each time the system is booted"
 msg_geli_setup="Initializing encryption on selected disks,\n this will take several seconds per disk"
@@ -1183,7 +1183,7 @@ zfs_create_boot()
 	#
 	f_dprintf "$funcname: Preparing disk partitions for ZFS pool..."
 
-	# Force 4K sectors using vfs.zfs.min_auto_ashift=12
+	# Force 4K sectors using vfs.zfs.vdev.min_auto_ashift=12
 	if [ "$ZFSBOOT_FORCE_4K_SECTORS" ]; then
 		f_dprintf "$funcname: With 4K sectors..."
 		f_eval_catch $funcname sysctl "$SYSCTL_ZFS_MIN_ASHIFT_12" \
@@ -1501,7 +1501,7 @@ zfs_create_boot()
 
 	if [ "$ZFSBOOT_FORCE_4K_SECTORS" ]; then
 		f_eval_catch $funcname echo "$ECHO_APPEND" \
-	             'vfs.zfs.min_auto_ashift=12' \
+	             'vfs.zfs.vdev.min_auto_ashift=12' \
 	             $BSDINSTALL_TMPETC/sysctl.conf.zfs || return $FAILURE
 	fi
 


### PR DESCRIPTION
Update references to the new sysctls:

kern.ipc.somaxconn       -> kern.ipc.soacceptqueue
vfs.zfs.arc_max          -> vfs.zfs.arc.max
vfs.zfs.arc_min          -> vfs.zfs.arc.min
vfs.zfs.min_auto_ashift  -> vfs.zfs.vdev.min_auto_ashift
vfs.zfs.prefetch_disable -> vfs.zfs.prefetch.disable
vfs.zfs.zil_disable      -> vfs.zfs.zil.replay_disable

There may be others, but this is a good start.

I fear this change may be too cross-cutting, feel free to break it into several digestible commits if necessary. Nevertheless, no functional changes are intended.

NOTE: Do not MFC to stable/12.