### PR TITLE
release: GCE: Remove python2

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -37,6 +37,8 @@ task:
   - gpart show
   - df -m
   - pkg --version
+  - pkg delete -y python2
+  - pkg upgrade -y
   - pw useradd user
   - mkdir -p /usr/obj/$(pwd -P)
   - chown user:user /usr/obj/$(pwd -P)

--- a/release/tools/gce.conf
+++ b/release/tools/gce.conf
@@ -9,8 +9,7 @@ export VMSIZE=20g
 # Set to a list of packages to install.
 export VM_EXTRA_PACKAGES="${VM_EXTRA_PACKAGES} firstboot-freebsd-update \
 	firstboot-pkgs \ google-cloud-sdk panicmail sudo \
-	sysutils/py-google-compute-engine lang/python lang/python2 \
-	lang/python3"
+	sysutils/py-google-compute-engine lang/python lang/python3"
 
 # Set to a list of third-party software to enable in rc.conf(5).
 export VM_RC_LIST="ntpd sshd growfs \


### PR DESCRIPTION
https://reviews.freebsd.org/D38766

This avoids having to manually remove the package from CirrusCI.

Wait until after 13.2-RELEASE to ping.