### PR TITLE
ping: Fix the spacing between the time stamp and cp/dp

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,54 +1,25 @@
 # $FreeBSD$
 
-compute_engine_instance:
-  # Image list available via
-  # gcloud compute images list --project freebsd-org-cloud-dev --no-standard-images
-  platform: freebsd
-  image_project: freebsd-org-cloud-dev
-  image: freebsd-13-1-release-amd64
-  cpu: 8
-  memory: 8G
-  disk: 40
+freebsd_instance:
+   image_family: freebsd-14-0-snap
 
 task:
-  matrix:
-  - name: World and kernel amd64 build and boot smoke test
-    env:
-      TARGET: amd64
-      TARGET_ARCH: amd64
-      TOOLCHAIN_PKG: llvm15
-  - name: World and kernel arm64 build and boot smoke test
-    trigger_type: manual
-    env:
-      TARGET: arm64
-      TARGET_ARCH: aarch64
-      TOOLCHAIN_PKG: llvm15
-  - name: World and kernel gcc12 amd64 build and boot smoke test
-    trigger_type: manual
-    env:
-      TARGET: amd64
-      TARGET_ARCH: amd64
-      TOOLCHAIN_PKG: amd64-gcc12
-  timeout_in: 120m
   install_script:
-  - sh .cirrus-ci/pkg-install.sh ${TOOLCHAIN_PKG}
+    - pkg delete -y python2
+    - pkg autoremove -y
+    - pkg update
+    - pkg upgrade -y
+    - pkg install -y devel/py-pytest net/scapy
+    - make -C libexec/atf/atf-pytest-wrapper -j$(sysctl -n hw.ncpu) all install
+    - make -C tests/sys/common -j$(sysctl -n hw.ncpu) all install
+    - make -C tests/atf_python -j$(sysctl -n hw.ncpu) all install
+    - cp $CIRRUS_WORKING_DIR/tests/conftest.py /usr/tests
   setup_script:
-  - uname -a
-  - gpart show
-  - df -m
-  - pkg --version
-  - pw useradd user
-  - mkdir -p /usr/obj/$(pwd -P)
-  - chown user:user /usr/obj/$(pwd -P)
-  script:
-  - su user -c "make -j$(sysctl -n hw.ncpu) CROSS_TOOLCHAIN=${TOOLCHAIN_PKG} WITHOUT_TOOLCHAIN=yes buildworld buildkernel"
-  package_script:
-  - su user -c "make CROSS_TOOLCHAIN=${TOOLCHAIN_PKG} WITHOUT_TOOLCHAIN=yes PKG_FORMAT=tar packages"
-  package_check_script:
-  - su user -c "/usr/libexec/flua tools/pkgbase/metalog_reader.lua -c /usr/obj/$(pwd -P)/${TARGET}.${TARGET_ARCH}/worldstage/METALOG"
-  test_script:
-  - sh .cirrus-ci/pkg-install.sh qemu-nox11
-  - sh tools/boot/ci-qemu-test.sh
-  post_script:
-  - df -m
-  - du -m -s /usr/obj
+    - make -C sbin/ping -j$(sysctl -n hw.ncpu) all install
+  test_ping_script:
+    - kyua test -k /usr/tests/Kyuafile sbin/ping/ping_test
+    - kyua test -k /usr/tests/Kyuafile sbin/ping/test_ping.py
+  always:
+    test_ping_report_script:
+      - cd /usr/tests
+      - kyua report --results-file=LATEST --results-filter=failed --verbose

--- a/sbin/ping/ping.c
+++ b/sbin/ping/ping.c
@@ -1299,14 +1299,14 @@ pr_pack(char *buf, ssize_t cc, struct sockaddr_in *from, struct timespec *tv)
 					for (i = 0; i < datalen; ++i, ++cp) {
 						if ((i % 16) == 8)
 							(void)printf("\n\t");
-						(void)printf("%2x ", *cp);
+						(void)printf(" %2x", *cp);
 					}
 					(void)printf("\ndp:");
 					cp = &outpack[ICMP_MINLEN];
 					for (i = 0; i < datalen; ++i, ++cp) {
 						if ((i % 16) == 8)
 							(void)printf("\n\t");
-						(void)printf("%2x ", *cp);
+						(void)printf(" %2x", *cp);
 					}
 					break;
 				}

--- a/sbin/ping/tests/test_ping.py
+++ b/sbin/ping/tests/test_ping.py
@@ -275,6 +275,8 @@ def redact(output):
         ("hlim=[0-9]*", "hlim="),
         ("ttl=[0-9]*", "ttl="),
         ("time=[0-9.-]*", "time="),
+        ("cp: .*", "cp:  xx xx xx xx xx xx xx xx"),
+        ("dp: .*", "dp:  xx xx xx xx xx xx xx xx"),
         ("\(-[0-9\.]+[0-9]+ ms\)", "(- ms)"),
         ("[0-9\.]+/[0-9.]+", "/"),
     ]
@@ -1290,6 +1292,39 @@ ping: time of day goes back (- ms), clamping time to 0
                 "redacted": True,
             },
             id="_0_0_special_warp",
+        ),
+        pytest.param(
+            {
+                "src": "192.0.2.1",
+                "dst": "192.0.2.2",
+                "icmp_type": 0,
+                "icmp_code": 0,
+                "special": "wrong",
+            },
+            {
+                "returncode": 0,
+                "stdout": """\
+PATTERN: 0x01
+PING 192.0.2.2 (192.0.2.2): 56 data bytes
+64 bytes from: icmp_seq=0 ttl= time= ms
+wrong data byte #55 should be 0x1 but was 0x0
+cp:  xx xx xx xx xx xx xx xx
+	  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1
+	  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1
+	  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  0
+dp:  xx xx xx xx xx xx xx xx
+	  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1
+	  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1
+	  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1
+
+--- 192.0.2.2 ping statistics ---
+1 packets transmitted, 1 packets received, 0.0% packet loss
+round-trip min/avg/max/stddev = /// ms
+""",
+                "stderr": "",
+                "redacted": True,
+            },
+            id="_0_0_special_wrong",
         ),
     ]
 


### PR DESCRIPTION
When an echo reply packet is received, the data is compared with the sent data.  When a wrong byte is detected the command displays a report with the differences.

The first row (the first 8-bytes of data after the ICMP header) should include the time stamp (if data is at least 8-bytes), this value is not taken into consideration for the comparison.  The remaining rows represent the data (padded pattern) received/sent, with each byte being compared for differences.

Print the space before (not after), to add an extra space after cp:/dp: for better readability when the first time stamp octet is not zero-padded, and to remove trailing spaces in the output.

Before:

    cp:99  0  0  c  1  5  c  0␣
        ab cd ab cd ab cd ab cd ab cd ab cd ab cd ab cd␣
        ...

After:

    cp: 99  0  0  c  1  5  c  0
         ab cd ab cd ab cd ab cd ab cd ab cd ab cd ab cd
         ...

Differential Revision:  https://reviews.freebsd.org/D39492