### PR TITLE
Fix arm64 cross compilation

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -16,7 +16,7 @@ env:
 task:
   matrix:
   - name: amd64-llvm15 World and kernel build and boot smoke test
-    only_if: $CIRRUS_REPO_FULL_NAME != 'freebsd/freebsd-src'
+    #only_if: $CIRRUS_REPO_FULL_NAME != 'freebsd/freebsd-src'
     trigger_type: manual
     env:
       TARGET: amd64
@@ -30,7 +30,7 @@ task:
       TOOLCHAIN: llvm16
       TOOLCHAIN_PKG: ${TOOLCHAIN}-lite
   - name: arm64-llvm15 World and kernel build and boot smoke test
-    only_if: $CIRRUS_REPO_FULL_NAME != 'freebsd/freebsd-src'
+    #only_if: $CIRRUS_REPO_FULL_NAME != 'freebsd/freebsd-src'
     trigger_type: manual
     env:
       TARGET: arm64
@@ -38,7 +38,7 @@ task:
       TOOLCHAIN: llvm15
       TOOLCHAIN_PKG: ${TOOLCHAIN}
   - name: arm64-llvm16 World and kernel build and boot smoke test
-    only_if: $CIRRUS_REPO_FULL_NAME != 'freebsd/freebsd-src'
+    #only_if: $CIRRUS_REPO_FULL_NAME != 'freebsd/freebsd-src'
     trigger_type: manual
     env:
       TARGET: arm64
@@ -46,7 +46,7 @@ task:
       TOOLCHAIN: llvm16
       TOOLCHAIN_PKG: ${TOOLCHAIN}
   - name: amd64-gcc12 World and kernel build and boot smoke test (manual)
-    only_if: $CIRRUS_REPO_FULL_NAME != 'freebsd/freebsd-src'
+    #only_if: $CIRRUS_REPO_FULL_NAME != 'freebsd/freebsd-src'
     trigger_type: manual
     env:
       TARGET: amd64
@@ -54,7 +54,7 @@ task:
       TOOLCHAIN: amd64-gcc12
       TOOLCHAIN_PKG: ${TOOLCHAIN}
   - name: aarch64-gcc12 World and kernel build and boot smoke test (manual)
-    only_if: $CIRRUS_REPO_FULL_NAME != 'freebsd/freebsd-src'
+    #only_if: $CIRRUS_REPO_FULL_NAME != 'freebsd/freebsd-src'
     trigger_type: manual
     env:
       TARGET: arm64
@@ -62,7 +62,7 @@ task:
       TOOLCHAIN: aarch64-gcc12
       TOOLCHAIN_PKG: ${TOOLCHAIN}
   - name: amd64-gcc12 World and kernel build and boot smoke test (FreeBSD repo)
-    only_if: $CIRRUS_REPO_FULL_NAME == 'freebsd/freebsd-src'
+    #only_if: $CIRRUS_REPO_FULL_NAME == 'freebsd/freebsd-src'
     env:
       TARGET: amd64
       TARGET_ARCH: amd64

--- a/.github/workflows/cross-bootstrap-tools.yml
+++ b/.github/workflows/cross-bootstrap-tools.yml
@@ -2,7 +2,7 @@ name: Cross-build Kernel
 
 on:
   push:
-    branches: [ main, 'stable/13' ]
+    branches: [ main, 'stable/13', 'fix-arm64-cross-compilation' ]
   pull_request:
     branches: [ main ]
 

--- a/sys/arm64/arm64/identcpu.c
+++ b/sys/arm64/arm64/identcpu.c
@@ -2704,11 +2704,11 @@ identify_cpu(u_int cpu)
 	desc->id_aa64mmfr0 = READ_SPECIALREG(id_aa64mmfr0_el1);
 	desc->id_aa64mmfr1 = READ_SPECIALREG(id_aa64mmfr1_el1);
 	desc->id_aa64mmfr2 = READ_SPECIALREG(id_aa64mmfr2_el1);
-	desc->id_aa64mmfr3 = READ_SPECIALREG(id_aa64mmfr3_el1);
-	desc->id_aa64mmfr4 = READ_SPECIALREG(id_aa64mmfr4_el1);
+	//desc->id_aa64mmfr3 = READ_SPECIALREG(id_aa64mmfr3_el1);
+	//desc->id_aa64mmfr4 = READ_SPECIALREG(id_aa64mmfr4_el1);
 	desc->id_aa64pfr0 = READ_SPECIALREG(id_aa64pfr0_el1);
 	desc->id_aa64pfr1 = READ_SPECIALREG(id_aa64pfr1_el1);
-	desc->id_aa64pfr2 = READ_SPECIALREG(id_aa64pfr2_el1);
+	//desc->id_aa64pfr2 = READ_SPECIALREG(id_aa64pfr2_el1);
 
 	/*
 	 * ID_AA64ZFR0_EL1 is only valid when at least one of:


### PR DESCRIPTION
Try `id_aa64mmfr3_el1`, `id_aa64mmfr4_el1`, and `id_aa64pfr2_el1` on real hardware.