### PR TITLE
jls: IPv4/v6 should use a hyphen with libxo

### DIFF
--- a/usr.sbin/jls/jls.c
+++ b/usr.sbin/jls/jls.c
@@ -51,7 +51,7 @@
 #define	JP_USER		0x01000000
 #define	JP_OPT		0x02000000
 
-#define JLS_XO_VERSION	"2"
+#define JLS_XO_VERSION	"3"
 
 #define	PRINT_DEFAULT	0x01
 #define	PRINT_HEADER	0x02
@@ -408,13 +408,13 @@ print_jail(int pflags, int jflags)
 #endif
 #ifdef INET
 		if (ip4_ok && !strcmp(params[n].jp_name, "ip4.addr")) {
-			emit_ip_addr_list(AF_INET, "ipv4_addrs", params + n);
+			emit_ip_addr_list(AF_INET, "ipv4-addrs", params + n);
 			n++;
 		}
 #endif
 #ifdef INET6
 		if (ip6_ok && !strcmp(params[n].jp_name, "ip6.addr")) {
-			emit_ip_addr_list(AF_INET6, "ipv6_addrs", params + n);
+			emit_ip_addr_list(AF_INET6, "ipv6-addrs", params + n);
 			n++;
 		}
 #endif


### PR DESCRIPTION
As stated in libxo's best practices, field names should be kebab-cased, it is better for XML output and JSON output can always use the XOF_UNDERSCORES flag to generate underscores.

Before:
    % jls --libxo json,pretty
    {
      "__version": "2",
      "jail-information": {
        "jail": [
          {
            ...
            "ipv4_addrs": [],
            "ipv6_addrs": []
          }
        ]
      }
    }

After:
    % jls --libxo json,pretty
    {
      "__version": "3",
      "jail-information": {
        "jail": [
          {
            ...
            "ipv4-addrs": [],
            "ipv6-addrs": []
          }
        ]
      }
    }

Or, if underscores are preferred:

    % jls --libxo json,underscore,pretty
    {
      "__version": "3",
      "jail_information": {
        "jail": [
          {
            ...
            "ipv4_addrs": [],
            "ipv6_addrs": []
          }
        ]
      }
    }