### PR TITLE
WIP KMSAN: kldload is blowing up

### DIFF
--- a/sbin/bectl/tests/bectl_test.sh
+++ b/sbin/bectl/tests/bectl_test.sh
@@ -47,7 +47,9 @@ bectl_create_setup()
 	# Sanity check to make sure `make_zpool_name` succeeded
 	atf_check test -n "$zpool"
 
-	kldload -n -q zfs || atf_skip "ZFS module not loaded on the current system"
+	if ! kldstat -q -m zfs; then
+		atf_skip "ZFS module not loaded on the current system"
+	fi
 	if ! getconf MIN_HOLE_SIZE "$(pwd)"; then
 		echo "getconf MIN_HOLE_SIZE $(pwd) failed; sparse files " \
 		    "probably not supported by file system"


### PR DESCRIPTION
```gdb
KDB: stack backtrace:
db_trace_self_wrapper() at db_trace_self_wrapper+0x9e/frame 0xfffffe0057aa38e0
vpanic() at vpanic+0x50c/frame 0xfffffe0057aa3a70
panic() at panic+0x1b9/frame 0xfffffe0057aa3b80
__msan_warning() at __msan_warning+0x23a/frame 0xfffffe0057aa3cd0
raidz_syn_pq_abd() at raidz_syn_pq_abd+0x45c/frame 0xfffffe0057aa3d90
abd_raidz_gen_iterate() at abd_raidz_gen_iterate+0x108d/frame 0xfffffe0057aa3ff0
scalar_rec_pq() at scalar_rec_pq+0xa6e/frame 0xfffffe0057aa4180
vdev_raidz_math_reconstruct() at vdev_raidz_math_reconstruct+0x408/frame 0xfffffe0057aa4220
vdev_raidz_reconstruct_row() at vdev_raidz_reconstruct_row+0x4e9/frame 0xfffffe0057aa4500
vdev_raidz_reconstruct() at vdev_raidz_reconstruct+0x10f/frame 0xfffffe0057aa4570
vdev_raidz_math_init() at vdev_raidz_math_init+0x113a/frame 0xfffffe0057aa46a0
spa_init() at spa_init+0x1de/frame 0xfffffe0057aa46e0
zfs_kmod_init() at zfs_kmod_init+0x62/frame 0xfffffe0057aa4720
zfs_modevent() at zfs_modevent+0xa3/frame 0xfffffe0057aa4770
module_register_init() at module_register_init+0x2c6/frame 0xfffffe0057aa4810
linker_load_module() at linker_load_module+0x405b/frame 0xfffffe0057aa4c20
kern_kldload() at kern_kldload+0x5e0/frame 0xfffffe0057aa4ce0
sys_kldload() at sys_kldload+0x1a9/frame 0xfffffe0057aa4d50
amd64_syscall() at amd64_syscall+0x2522/frame 0xfffffe0057aa4f30
fast_syscall_common() at fast_syscall_common+0xf8/frame 0xfffffe0057aa4f30
--- syscall (304, FreeBSD ELF64, kldload), rip = 0x4674ef775ba, rsp = 0x4674d18eb68, rbp = 0x4674d18f0e0 ---
KDB: enter: panic
[ thread pid 56696 tid 101144 ]
Stopped at      kdb_enter+0x16f:        movq    $0x85dd3010,%rdi
db:0:kdb.enter.panic> show pcpu
cpuid        = 1
dynamic pcpu = 0xfffffe009ae62240
curthread    = 0xfffffe005e59fc80: pid 56696 tid 101144 critnest 2 "kldload"
curpcb       = 0xfffffe005e5a01a0
fpcurthread  = none
idlethread   = 0xfffffe003264ec80: tid 100004 "idle: cpu1"
self         = 0xffffffff86611000
curpmap      = 0xfffffe005e401868
tssp         = 0xffffffff86611384
rsp0         = 0xfffffe0057aa5000
kcr3         = 0x8000000118ec92da
ucr3         = 0x80000001d6c22ada
scr3         = 0x1d6c22ada
gs32p        = 0xffffffff86611404
ldt          = 0xffffffff86611444
tss          = 0xffffffff86611434
curvnet      = 0xfffffe001fc82000
spin locks held:
db:0:kdb.enter.panic>  reset
```