### PR TITLE
release: Remove kernel_dbg selection by default

### DIFF
--- a/release/scripts/make-manifest.sh
+++ b/release/scripts/make-manifest.sh
@@ -33,7 +33,7 @@ default_tests=off
 default_base_dbg=off
 default_lib32_dbg=off
 default_kernel_alt=off
-default_kernel_dbg=on
+default_kernel_dbg=off
 default_kernel_alt_dbg=off
 
 for i in ${*}; do


### PR DESCRIPTION
When releasing, `default_kernel_dbg` should be turned off.

---

Ask release engineering first.