### PR TITLE
rc.initdiskless: Disable soft-updates in mdmfs (again)

### DIFF
--- a/libexec/rc/rc.initdiskless
+++ b/libexec/rc/rc.initdiskless
@@ -208,9 +208,9 @@ handle_remount() { # $1 = mount point
 # $1 is size in 512-byte sectors, $2 is the mount point.
 mount_md() {
     if [ ${o_verbose} -gt 0 ] ; then
-        /sbin/mdmfs -XL -s $1 auto $2
+        /sbin/mdmfs -XL -S -i 4096 -s $1 auto $2
     else
-        /sbin/mdmfs -s $1 auto $2
+        /sbin/mdmfs -S -i 4096 -s $1 auto $2
     fi
 }
 


### PR DESCRIPTION
PR:	85558

---

Discovered this one while bringing nanobsd/dhcpd back to life. Ask @bsdimp if this is still relevant before submitting.
