### PR TITLE
makefs: Allow special characters in a ZFS pool

### DIFF
--- a/usr.sbin/makefs/zfs.c
+++ b/usr.sbin/makefs/zfs.c
@@ -219,7 +219,9 @@ zfs_check_opts(fsinfo_t *fsopts)
 	if (!isalpha(zfs->poolname[0]))
 		errx(1, "the pool name must begin with a letter");
 	for (size_t i = 0, len = strlen(zfs->poolname); i < len; i++) {
-		if (!isalnum(zfs->poolname[i]) && zfs->poolname[i] != '_')
+		if (!isalnum(zfs->poolname[i]) && zfs->poolname[i] != '-' &&
+		    zfs->poolname[i] != '_' && zfs->poolname[i] != '.' &&
+		    zfs->poolname[i] != ':' && zfs->poolname[i] != ' ')
 			errx(1, "invalid character '%c' in pool name",
 			    zfs->poolname[i]);
 	}


### PR DESCRIPTION
ZFS pool names can also have '-', '.', ':', ' ' characters.

XXX: Tests