### PR TITLE
newfs_msdos: Update the OEM label

### DIFF
--- a/sbin/newfs_msdos/mkfs_msdos.c
+++ b/sbin/newfs_msdos/mkfs_msdos.c
@@ -728,7 +728,7 @@ mkfs_msdos(const char *fname, const char *dtype, const struct msdos_options *op)
 		    mk1(bs->bsJump[0], 0xeb);
 		    mk1(bs->bsJump[1], x1 - 2);
 		    mk1(bs->bsJump[2], 0x90);
-		    setstr(bs->bsOemName, o.OEM_string ? o.OEM_string : "BSD4.4  ",
+		    setstr(bs->bsOemName, o.OEM_string ? o.OEM_string : "FreeBSD",
 			   sizeof(bs->bsOemName));
 		    memcpy(img + x1, bootcode, sizeof(bootcode));
 		    mk2(img + MINBPS - 2, DOSMAGIC);

--- a/sbin/newfs_msdos/newfs_msdos.8
+++ b/sbin/newfs_msdos/newfs_msdos.8
@@ -23,7 +23,7 @@
 .\" OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 .\" IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .\"
-.Dd June 6, 2024
+.Dd September 1, 2024
 .Dt NEWFS_MSDOS 8
 .Os
 .Sh NAME
@@ -118,7 +118,7 @@ only those characters permitted in regular DOS (8+3) filenames.
 .It Fl O Ar OEM
 OEM string (up to 8 characters).
 The default is
-.Qq Li "BSD4.4  " .
+.Qq Li "FreeBSD" .
 .It Fl S Ar sector-size
 Number of bytes per sector.
 Acceptable values are powers of 2


### PR DESCRIPTION
Mimic NetBSD[^1], and update the default OEM label for newfs_msdos. BSD4.4 had no newfs_msdos command.

[^1]: https://github.com/NetBSD/src/commit/5240695a2f0dbd90de42963c8b9d945a63335f83