### PR TITLE
vtnet: Fix an LOR in the input path

### DIFF
--- a/sys/dev/virtio/network/if_vtnet.c
+++ b/sys/dev/virtio/network/if_vtnet.c
@@ -2008,6 +2008,8 @@ vtnet_rxq_input(struct vtnet_rxq *rxq, struct mbuf *m,
 	struct vtnet_softc *sc;
 	if_t ifp;
 
+	VTNET_RXQ_LOCK_ASSERT(rxq);
+
 	sc = rxq->vtnrx_sc;
 	ifp = sc->vtnet_ifp;
 
@@ -2056,7 +2058,9 @@ vtnet_rxq_input(struct vtnet_rxq *rxq, struct mbuf *m,
 	}
 #endif
 
+	VTNET_RXQ_UNLOCK(rxq);
 	if_input(ifp, m);
+	VTNET_RXQ_LOCK(rxq);
 }
 
 static int


### PR DESCRIPTION
if_vtnet holds a queue lock when processing incoming packets. It sends them up the stack without dropping the lock, which is incorrect. For example, witness generates warnings when if_vtnet receives ND6 packets.

Simply drop the lock before entering the network stack. We could batch this by linking a small number of packets using m_nextpkt; ether_input() handles such batches.

https://reviews.freebsd.org/D45950
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=253888